### PR TITLE
Fix build issues with Mingw-w64 

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ if host_machine.system() == 'windows'
   hidapi_sources += 'windows/hid.c'
   cc = meson.get_compiler('c')
   hidapi_deps = cc.find_library('setupapi', required : true)
-  hidapi_link_args += '--no-undefined'
+  hidapi_link_args += '-Wall'
 elif host_machine.system() == 'linux'
   hidapi_sources += 'libusb/hid.c'
   hidapi_deps = [

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ if host_machine.system() == 'windows'
   hidapi_sources += 'windows/hid.c'
   cc = meson.get_compiler('c')
   hidapi_deps = cc.find_library('setupapi', required : true)
-  hidapi_link_args += '--no-undefined'
+  hidapi_link_args += '-Wno-undef'
 elif host_machine.system() == 'linux'
   hidapi_sources += 'libusb/hid.c'
   hidapi_deps = [

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ if host_machine.system() == 'windows'
   hidapi_sources += 'windows/hid.c'
   cc = meson.get_compiler('c')
   hidapi_deps = cc.find_library('setupapi', required : true)
-  hidapi_link_args += '-Wno-undef'
+  hidapi_link_args += '--no-undefined'
 elif host_machine.system() == 'linux'
   hidapi_sources += 'libusb/hid.c'
   hidapi_deps = [


### PR DESCRIPTION
While building using Mingw-w64 on a ubuntu 20.04 linux subsystem on windows I ran into the 
following issue when I ran ninja.

```
[2/2] Linking target libhidapi.dll.
FAILED: libhidapi.dll
/usr/bin/x86_64-w64-mingw32-gcc  -o libhidapi.dll 'hidapi@sha/windows_hid.c.obj' -Wl,--allow-shlib-undefined -shared -Wl,--start-group -Wl,--out-implib=libhidapi.dll.a -static -static-libgcc --no-undefined -lsetupapi -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -Wl,--end-group
x86_64-w64-mingw32-gcc: error: unrecognized command line option ‘--no-undefined’; did you mean ‘-Wno-undef’?
ninja: build stopped: subcommand failed.
```
I removed the --no-undefined arg since it prevented the build and didn't seem required on linux.


